### PR TITLE
Fixed filters so that cuda deps are pulled only for cuda variant of j…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,9 @@ source:
     - patches/0004-Remove-bazel-shutdown-call-from-jax-code.patch      #[x86_64]
 
 build:
-  number: 3
-  string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
+  number: 4
+  string: {{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
+  string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 {% if build_type == 'cuda' %}
   script_env:
     - CUDA_HOME
@@ -34,7 +34,7 @@ requirements:
   build:
     - {{ compiler('c') }}                    # [ ppc_arch != "p10"]
     - {{ compiler('cxx') }}                  # [ ppc_arch != "p10"]
-    - {{ compiler('cuda') }}                 # [cuda_compiler_version != "None"]
+    - {{ compiler('cuda') }}                 # [build_type == 'cuda']
     - python {{ python }}                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - numpy {{ numpy }}                                 # [build_platform != target_platform]
@@ -51,8 +51,8 @@ requirements:
     # list libabseil here to ensure pinning correctly
     - libabseil {{ abseil_cpp }}
   host:
-    - cudnn {{ cudnn }}      # [cuda_compiler_version != "None"]
-    - nccl {{ nccl }}       # [cuda_compiler_version != "None"]
+    - cudnn {{ cudnn }}      # [build_type == 'cuda']
+    - nccl {{ nccl }}        # [build_type == 'cuda']
     - python {{ python }}
     - pip
     - numpy {{ numpy }}
@@ -71,7 +71,7 @@ requirements:
     - re2
     - c-ares
     - libopenblas {{ openblas }}
-    - nccl {{ nccl }}      #[build_type == 'cuda']
+    - nccl {{ nccl }}           #[build_type == 'cuda']
     - ml_dtypes >=0.0.3
       #- __cuda  # [cuda_compiler_version != "None"]
   run_constrained:


### PR DESCRIPTION
…axlib

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Earlier the build string of jaxlib was `jaxlib-0.4.7-cuda118py310h8da137d_3.conda` whereas it should be in our usual format like this `jaxlib-0.4.7-cuda11.8_py310_pb4.21.12_3.conda`. 
The main issue is cuda packages were being pulled when cpu only packages were to be installed. And the reason for this the filters that were used with `nccl` dependency in the recipe of jaxlib. So, after using the open-ce defined filters like `#[build_type == 'cuda']` , this problem is solved.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
