### PR TITLE
[1.10] Remove cudnn pin to favour global pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,5 +8,3 @@ cuda_compiler_version:
   - "11.8"                   # [cudatoolkit == '11.8']
 cuda_compiler:
   - nvcc
-cudnn:
-  - 8.8.1


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
The follow error is seen due to this local pin - although the global pin for OpenCE 1.10 is 8.9 - https://github.com/open-ce/open-ce/blob/open-ce-r1.10/envs/conda_build_config.yaml#L57
```
conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-64: {'cudnn=8.8.1'}
[OPEN-CE-ERROR]-11 Unable to build recipe: jaxlib-feedstock
[OPEN-CE-ERROR]-11 Unable to build recipe: jaxlib
Unsatisfiable dependencies for platform linux-64: {'cudnn=8.8.1'}
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
